### PR TITLE
修正台湾异体字的处理

### DIFF
--- a/src/main/java/com/github/houbb/opencc4j/support/data/impl/TwSTCharData.java
+++ b/src/main/java/com/github/houbb/opencc4j/support/data/impl/TwSTCharData.java
@@ -2,12 +2,15 @@ package com.github.houbb.opencc4j.support.data.impl;
 
 import com.github.houbb.heaven.annotation.ThreadSafe;
 import com.github.houbb.opencc4j.model.data.DataInfo;
+import com.github.houbb.opencc4j.util.ZhConverterUtil;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
  * 中国台湾 简写=》繁写 字符
+ *
  * @author binbin.hou
  * @author jackychu0830
  * @since 1.7.0
@@ -22,9 +25,28 @@ public class TwSTCharData extends AbstractData {
 
     static {
         DATA_INFO = new DataInfo();
-        Map<String, List<String>> data = DataUtil.buildDataMap("/data/dictionary/STCharacters.txt");
+        Map<String, List<String>> data = new HashMap<>(DataUtil.buildDataMap("/data/dictionary/STCharacters.txt"));
+
         Map<String, List<String>> dataTw = DataUtil.buildDataMap("/data/dictionary/TWVariants.txt");
-        DataUtil.merge(data, dataTw);
+        for (String key : dataTw.keySet()) {
+            // 先将繁体的 key 转成简体
+            String sKey = ZhConverterUtil.toSimple(key);
+            // 找到简体字符
+            if (data.containsKey(sKey)) {
+                // 取出原本的值
+                List<String> values = data.get(sKey);
+                // 找出符合的繁体字符，替换成异体字符
+                // TWVariants.txt 只有1对1 对应，所以只取 index 0 的值
+                int index = values.indexOf(key);
+                if (index != -1) {
+                    values.set(index, dataTw.get(key).get(0));
+                }
+            } else {
+                // 若无对应，则新增一组
+                data.put(sKey, dataTw.get(key));
+            }
+        }
+
         DATA_INFO.setDataMap(data);
         DATA_INFO.setName("中国台湾简体转繁体字符数据");
     }

--- a/src/main/java/com/github/houbb/opencc4j/support/data/impl/TwTSCharData.java
+++ b/src/main/java/com/github/houbb/opencc4j/support/data/impl/TwTSCharData.java
@@ -26,8 +26,6 @@ public class TwTSCharData extends AbstractData {
             DATA_INFO = new DataInfo();
 
             Map<String, List<String>> data = DataUtil.buildDataMap("/data/dictionary/TSCharacters.txt");
-            Map<String, List<String>> dataTw = DataUtil.buildDataMapReverse("/data/dictionary/TWVariants.txt");
-            DataUtil.merge(data, dataTw);
             DATA_INFO.setDataMap(data);
             DATA_INFO.setName("中国台湾繁体转简体字符数据");
         }

--- a/src/main/java/com/github/houbb/opencc4j/support/segment/trie/TwOpenccTrieTreeMap.java
+++ b/src/main/java/com/github/houbb/opencc4j/support/segment/trie/TwOpenccTrieTreeMap.java
@@ -38,11 +38,9 @@ public class TwOpenccTrieTreeMap extends AbstractTrieTreeMap {
         Set<String> resultSet = Guavas.newHashSet();
 
         //1. 简体词组的 keys
-        resultSet.addAll(OpenccDatas.stPhrase().data().getDataMap().keySet());
         resultSet.addAll(OpenccDatas.twStPhrase().data().getDataMap().keySet());
 
         //2. 繁体词组的 keys
-        resultSet.addAll(OpenccDatas.tsPhrase().data().getDataMap().keySet());
         resultSet.addAll(OpenccDatas.twTsPhrase().data().getDataMap().keySet());
 
         return resultSet;

--- a/src/test/java/com/github/houbb/opencc4j/util/ZhTwConverterUtilTest.java
+++ b/src/test/java/com/github/houbb/opencc4j/util/ZhTwConverterUtilTest.java
@@ -54,7 +54,7 @@ public class ZhTwConverterUtilTest {
     public void testTwVariants() throws Exception {
         String original = "为什么嘴唇裂了";
         String result = ZhTwConverterUtil.toTraditional(original);
-        Assert.assertEquals("爲什麼嘴脣裂了", result);
+        Assert.assertEquals("為什麼嘴唇裂了", result);
     }
 
 }


### PR DESCRIPTION
TWVariants.txt 是繁体对繁体的字符，所以需要把原来 STCharacters.txt 的字符取代掉
例如："为 爲" 要改成 "为 為" 
不能直接 merge 覆盖，因为有一对多的情况
例如: "里 裏 里" 要改成 "里 裡 里"

合并的代码有点丑，而且有些词组就是转不过
例如:
里面 => 裏面 (应为 裡面)
硅谷 => 硅谷 (应为 矽谷), 但 硅胶 又可以正确转译为 矽膠
